### PR TITLE
Fix MIDI meta length parsing for >127 byte entries

### DIFF
--- a/miditones.c
+++ b/miditones.c
@@ -838,7 +838,7 @@ void find_note (int tracknum) {
       }
       if (event == 0xff) {      /* meta-event */
          meta_cmd = *t->trkptr++;
-         meta_length = *t->trkptr++;
+         meta_length = get_varlen (&t->trkptr);
          switch (meta_cmd) {
          case 0x00:
             if (logparse)


### PR DESCRIPTION
Howdy,

Thanks for MIDITONES!  I'm using a heavily modified version paired with a real-time Soundfont based wavetable synthesier for the ESP8266 Arduino, and found a small bug in META field processing.  It's a 10 character change that properly interprets files like those at www.kunstderfuge.com/mozart.htm which have >128 byte comment fields for copyright/etc.

...snip...
In find_note, the meta_len was hardcoded as a single byte encoding, but per
the spec and some files with long comments and copyrights, it is actually
encoded as a varlen.  Use the varlen parser (which defaults to the old
behavior of 1-byte for <128 len fields) instead.
...snip...

Thanks,
-EFP3